### PR TITLE
ignore libs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
 **/*.spec.js
 /cypress
+/node_modules/
+/libs/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,3 @@
 images
+/node_modules/
+/libs/


### PR DESCRIPTION
No readme orientamos a possibilidade de utilização de libs usando a pasta libs, pensando nisso, é necessário fazer com que os lints ignorem as libs.